### PR TITLE
Add health monitoring for indexing dependencies (#62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ node_modules/
 .DS_Store
 *.db
 qdrant_store*
+db/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- Show the Qdrant data path and endpoint on the same line in the TTY monitoring Configuration panel.
+- Show model and Qdrant health states with green and red indicators in the TTY monitoring Configuration panel.
+- Pause index workers while Qdrant or the configured LLM is unhealthy, while retaining queued `/index` requests for automatic recovery.
 - Add a TTY monitoring dashboard for server configuration, queues, database activity, and MCP tools.
 - Migrate generator setup from deprecated `OpenAIGenerator`, `AmazonBedrockGenerator`, and `OllamaGenerator`
   to chat-based generators.
@@ -11,5 +14,11 @@
 
 ### Fixes
 
+- Prevent the server-context unit test from creating a Docker-managed Qdrant container.
+- Select available localhost ports through Python before creating the Docker-managed Qdrant database.
+- Probe Qdrant using its configured endpoint after the database is restarted instead of reusing private state from a failed client.
+- Allow the health monitor to report Qdrant healthy again after a temporary disconnection.
+- Keep the monitoring dashboard running when Qdrant disconnects while loading document counts.
+- Keep the health monitor alive when Qdrant disconnects during a health check.
 - Prevent persistent queue workers from racing to create queue directories during first-time initialization.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ python3 mcp_service.py --open-world false
 
 The MCP tools will index data if appropriate. For example, spidering and directory busting. Data can be indexed by external means using the `/index` endpoint. The endpoint is not part of an MCP tool or protocol.
 
+Indexing workers monitor Qdrant and LLM readiness. If either dependency is unhealthy, `/index` requests continue to be accepted into the persistent queue, but ingest and type-specific indexing pause before consuming new items. Workers resume automatically after both health checks recover; MCP tools retain their existing request and error behavior.
+
 ```shell
 curl -X POST -H "Content-Type: application/json" http://127.0.0.1:8000/index @katana.json
 ```

--- a/shyhurricane/db.py
+++ b/shyhurricane/db.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import json
+import socket
 import subprocess
 import time
 import requests
@@ -72,6 +73,14 @@ def _get_published_port(inspect: dict, container_port: str) -> Tuple[str, int]:
     return host_ip, int(host_port)
 
 
+def _find_available_port(host: str) -> int:
+    listener = socket.create_server((host, 0))
+    try:
+        return listener.getsockname()[1]
+    finally:
+        listener.close()
+
+
 def _start_qdrant_docker(
         *,
         name: str = "qdrant-shyhurricane-db",
@@ -87,7 +96,7 @@ def _start_qdrant_docker(
         - If running: reuse it.
         - If stopped: start it.
       (No recreation, no port changes.)
-    - If it doesn't exist: create it with auto-assigned host ports, bound to `host_bind`.
+    - If it doesn't exist: create it with available host ports, bound to `host_bind`.
     - Returns the bound host ports discovered via docker inspect.
     """
     storage = Path(storage_dir).resolve()
@@ -98,7 +107,10 @@ def _start_qdrant_docker(
 
     inspect = _inspect_container(name)
     if inspect is None:
-        # Auto-assign host ports by leaving host port empty, but still bind to localhost
+        http_host_port = _find_available_port(host_bind)
+        grpc_host_port = _find_available_port(host_bind)
+        while grpc_host_port == http_host_port:
+            grpc_host_port = _find_available_port(host_bind)
         _run(
             [
                 "docker",
@@ -107,9 +119,9 @@ def _start_qdrant_docker(
                 "--name",
                 name,
                 "-p",
-                f"{host_bind}::{http_container_port}",
+                f"{host_bind}:{http_host_port}:{http_container_port}",
                 "-p",
-                f"{host_bind}::{grpc_container_port}",
+                f"{host_bind}:{grpc_host_port}:{grpc_container_port}",
                 "-v",
                 f"{str(storage)}:/qdrant/storage:rw",
                 image,

--- a/shyhurricane/health.py
+++ b/shyhurricane/health.py
@@ -1,0 +1,73 @@
+import logging
+import multiprocessing
+import threading
+from collections.abc import Callable
+
+from qdrant_client import QdrantClient
+
+logger = logging.getLogger(__name__)
+
+
+class HealthMonitor:
+    """Periodically checks indexing dependencies and exposes shared readiness."""
+
+    def __init__(self, qdrant_probe: Callable[[], object], llm_probe: Callable[[], object], interval: float = 10):
+        self.ready = multiprocessing.Event()
+        self._qdrant_probe = qdrant_probe
+        self._llm_probe = llm_probe
+        self._interval = interval
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="health-monitor", daemon=True)
+        self._last_state = None
+        self.qdrant_healthy: bool | None = None
+        self.llm_healthy: bool | None = None
+
+    def start(self):
+        self._thread.start()
+
+    def close(self):
+        self._stop.set()
+        self._thread.join(timeout=self._interval + 1)
+
+    def check(self) -> bool:
+        try:
+            qdrant_healthy = bool(self._qdrant_probe())
+        except Exception:
+            logger.warning("Qdrant health check failed", exc_info=True)
+            qdrant_healthy = False
+        self.qdrant_healthy = qdrant_healthy
+        try:
+            llm_healthy = bool(self._llm_probe())
+        except Exception:
+            logger.warning("LLM health check failed", exc_info=True)
+            llm_healthy = False
+        self.llm_healthy = llm_healthy
+        healthy = qdrant_healthy and llm_healthy
+        if healthy:
+            self.ready.set()
+        else:
+            self.ready.clear()
+        if healthy != self._last_state:
+            logger.info("Indexing dependencies are %s", "healthy" if healthy else "unhealthy")
+            self._last_state = healthy
+        return healthy
+
+    def _run(self):
+        while not self._stop.is_set():
+            try:
+                self.check()
+            except Exception:
+                logger.warning("Health monitor check failed", exc_info=True)
+                self.qdrant_healthy = False
+                self.llm_healthy = False
+                self.ready.clear()
+            self._stop.wait(self._interval)
+
+
+def qdrant_probe(host: str, port: int) -> bool:
+    probe_client = QdrantClient(host=host, port=port)
+    try:
+        probe_client.get_collections()
+    finally:
+        probe_client.close()
+    return True

--- a/shyhurricane/index/web_resources.py
+++ b/shyhurricane/index/web_resources.py
@@ -25,7 +25,18 @@ if TYPE_CHECKING:
     from shyhurricane.task_queue.types import TaskPool
 
 
-def _ingest_worker(db: str, generator_config: GeneratorConfig):
+def _wait_for_health(health_state) -> bool:
+    if health_state is None:
+        return True
+    while not health_state.is_set():
+        if hasattr(health_state, "wait"):
+            health_state.wait(timeout=1)
+        else:
+            return False
+    return True
+
+
+def _ingest_worker(db: str, generator_config: GeneratorConfig, health_state=None):
     prepare_worker_process()
     try:
         faulthandler.register(signal.SIGUSR1)
@@ -42,7 +53,12 @@ def _ingest_worker(db: str, generator_config: GeneratorConfig):
 
         pipeline: Pipeline = build_ingest_pipeline(db=db, generator_config=generator_config)
         logger.info(f"Index worker ready in PID {os.getpid()}, logging to {index_log_path}")
-        for item in persistent_queue_get(queue, shrink_count=1000):
+        queue_items = iter(persistent_queue_get(queue, shrink_count=1000))
+        while _wait_for_health(health_state):
+            try:
+                item = next(queue_items)
+            except StopIteration:
+                break
             logger.info(f"Processing {item[0:128]} in PID {os.getpid()}")
 
             if index_log_path is not None:
@@ -77,6 +93,30 @@ def _ingest_worker(db: str, generator_config: GeneratorConfig):
     logger.info(f"Index worker finished in PID {os.getpid()}")
 
 
+def _ingest_watcher(db: str, generator_config: GeneratorConfig, health_state=None):
+    prepare_worker_process()
+    process = None
+    try:
+        while True:
+            process = multiprocessing.Process(target=_ingest_worker, args=(db, generator_config, health_state))
+            process.start()
+            process.join()
+            exitcode = process.exitcode
+            process.close()
+            process = None
+            if exitcode != 0:
+                break
+            if health_state is not None:
+                _wait_for_health(health_state)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if process is not None:
+            process.terminate()
+            process.join()
+            process.close()
+
+
 def is_current_process_in_bad_state() -> bool:
     """
     Determine if this process is in a bad state. In a unified memory architecture, allocating GPU memory beyond a
@@ -95,7 +135,7 @@ def is_current_process_in_bad_state() -> bool:
     return False
 
 
-def _doc_type_worker(db: str, generator_config: GeneratorConfig):
+def _doc_type_worker(db: str, generator_config: GeneratorConfig, health_state=None):
     exit_code = -1
     try:
         faulthandler.register(signal.SIGUSR1)
@@ -108,7 +148,12 @@ def _doc_type_worker(db: str, generator_config: GeneratorConfig):
         pipeline: Pipeline = build_doc_type_pipeline(db=db, generator_config=generator_config)
 
         logger.info(f"Document specific index worker ready in PID {os.getpid()}")
-        for item in persistent_queue_get(doc_type_queue, shrink_count=100):
+        queue_items = iter(persistent_queue_get(doc_type_queue, shrink_count=100))
+        while _wait_for_health(health_state):
+            try:
+                item = next(queue_items)
+            except StopIteration:
+                break
             logger.info(f"Processing document {item.id} in PID {os.getpid()}")
             try:
                 pipeline.run({"input": {"documents": [item]}})
@@ -129,7 +174,7 @@ def _doc_type_worker(db: str, generator_config: GeneratorConfig):
     return exit_code
 
 
-def _doc_type_watcher(db: str, generator_config: GeneratorConfig):
+def _doc_type_watcher(db: str, generator_config: GeneratorConfig, health_state=None):
     """
     The watcher process maintains a doc type index process. It will start a new one if the process exits successfully,
     indicating it exited due to excessive memory usage.
@@ -141,14 +186,16 @@ def _doc_type_watcher(db: str, generator_config: GeneratorConfig):
         logger.info(f"Document specific index watcher starting in PID {os.getpid()}")
 
         while True:
-            process = multiprocessing.Process(target=_doc_type_worker, args=(db, generator_config))
+            process = multiprocessing.Process(target=_doc_type_worker, args=(db, generator_config, health_state))
             process.start()
             process.join()
             exitcode = process.exitcode
             process.close()
             process = None
-            if exitcode != 0:
+            if exitcode != 0 and (health_state is None or health_state.is_set()):
                 break
+            if health_state is not None:
+                _wait_for_health(health_state)
 
     except KeyboardInterrupt:
         pass
@@ -165,7 +212,7 @@ def _doc_type_watcher(db: str, generator_config: GeneratorConfig):
     logger.info(f"Document specific index watcher finished in PID {os.getpid()}")
 
 
-def start_ingest_worker(db: str, generator_config: GeneratorConfig, pool_size: int = 1) -> Tuple[
+def start_ingest_worker(db: str, generator_config: GeneratorConfig, pool_size: int = 1, health_state=None) -> Tuple[
     persistqueue.SQLiteAckQueue, "TaskPool"]:
     from shyhurricane.task_queue.types import TaskPool
 
@@ -177,13 +224,13 @@ def start_ingest_worker(db: str, generator_config: GeneratorConfig, pool_size: i
     else:
         for idx in range(pool_size):
             # these processes are heavy-weight
-            process = multiprocessing.Process(target=_doc_type_watcher, args=(db, generator_config))
+            process = multiprocessing.Process(target=_doc_type_watcher, args=(db, generator_config, health_state))
             process._shyhurricane_monitor_process_group = os.environ.get("SHYHURRICANE_MONITOR") == "1"
             process.start()
             processes.append(process)
 
     # this is a light-weight process, we only need one
-    ingest_process = multiprocessing.Process(target=_ingest_worker, args=(db, generator_config))
+    ingest_process = multiprocessing.Process(target=_ingest_watcher, args=(db, generator_config, health_state))
     ingest_process._shyhurricane_monitor_process_group = os.environ.get("SHYHURRICANE_MONITOR") == "1"
     ingest_process.start()
     processes.append(ingest_process)

--- a/shyhurricane/mcp_server/server_context.py
+++ b/shyhurricane/mcp_server/server_context.py
@@ -19,8 +19,9 @@ from shyhurricane.index.web_resources_pipeline import build_stores
 from shyhurricane.server_config import get_server_config
 from shyhurricane.mcp_server.generator_config import get_generator_config
 from shyhurricane.retrieval_pipeline import build_document_pipeline, build_website_context_pipeline
-from shyhurricane.db import create_qdrant_client, create_qdrant_document_store
+from shyhurricane.db import create_qdrant_client, create_qdrant_document_store, qdrant_host_port
 from shyhurricane.utils import unix_command_image
+from shyhurricane.health import HealthMonitor, qdrant_probe
 
 logger = logging.getLogger(__name__)
 
@@ -50,14 +51,19 @@ class ServerContext:
     stores: Dict[str, QdrantDocumentStore]
     qdrant_client: AsyncQdrantClient
     mcp_session_volume: str
+    qdrant_host: Optional[str] = None
+    qdrant_port: Optional[int] = None
     open_world: bool = True
     commands: Optional[List[str]] = None
     disable_elicitation: bool = False
     proxy_host: Optional[str] = None
     proxy_port: Optional[int] = None
     proxy_ca_cert_path: Optional[os.PathLike] = None
+    health_monitor: Optional[HealthMonitor] = None
 
     def close(self):
+        if self.health_monitor is not None:
+            self.health_monitor.close()
         logger.info("Terminating task pool")
         self.task_pool.close()
         logger.info("Terminating ingest pool")
@@ -108,6 +114,9 @@ async def get_server_context() -> ServerContext:
     os.makedirs(cache_path, exist_ok=True)
     disable_elicitation = bool(os.environ.get('DISABLE_ELICITATION', 'False'))
     qdrant_client = await create_qdrant_client(db=db)
+    qdrant_host, qdrant_port = qdrant_host_port(db)
+    health_monitor = HealthMonitor(lambda: qdrant_probe(qdrant_host, qdrant_port), lambda: True)
+    health_monitor.start()
 
     mcp_session_volume = "mcp_session"
 
@@ -143,6 +152,7 @@ async def get_server_context() -> ServerContext:
         db=db,
         generator_config=generator_config,
         pool_size=server_config.ingest_pool_size,
+        health_state=health_monitor.ready,
     )
     task_worker_ipc = start_task_worker(db, ingest_queue.path, server_config.task_pool_size)
 
@@ -175,8 +185,11 @@ async def get_server_context() -> ServerContext:
         stores=stores,
         qdrant_client=qdrant_client,
         mcp_session_volume=mcp_session_volume,
+        qdrant_host=qdrant_host,
+        qdrant_port=qdrant_port,
         disable_elicitation=disable_elicitation,
         open_world=server_config.open_world,
+        health_monitor=health_monitor,
     )
 
     return _server_context

--- a/shyhurricane/monitor.py
+++ b/shyhurricane/monitor.py
@@ -21,8 +21,12 @@ class MonitorData:
     bound_address: str
     proxy_address: str
     model: str
+    model_health: bool | None
     certificate_fingerprint: str | None
     database: str
+    qdrant_host_bind: str | None
+    qdrant_http_port: int | None
+    qdrant_health: bool | None
     document_counts: dict[str, int]
     domain_count: int
     host_count: int
@@ -102,11 +106,33 @@ def format_domain_and_host_panel(data: MonitorData) -> str:
     )
 
 
+def health_label(healthy: bool | None) -> str:
+    if healthy is None:
+        return "(unavailable)"
+    return "🟢" if healthy else "🔴"
+
+
+def format_configuration_panel(data: MonitorData) -> str:
+    fingerprint = data.certificate_fingerprint or "unavailable"
+    qdrant_host_bind = data.qdrant_host_bind or "unavailable"
+    qdrant_http_port = data.qdrant_http_port if data.qdrant_http_port is not None else "unavailable"
+    return (
+        "[b]Configuration[/b]\n"
+        f"Model: {data.model} {health_label(data.model_health)}\n"
+        f"Qdrant: {data.database} {qdrant_host_bind}:{qdrant_http_port} {health_label(data.qdrant_health)}\n"
+        f"MCP: {data.bound_address}\n"
+        f"Proxy: {data.proxy_address}\nTLS SHA-256: {fingerprint}"
+    )
+
+
 async def collect_monitor_data(server_context, host: str, port: int, running_tools: Iterable[str]) -> MonitorData:
-    document_counts = {
-        collection_name: await store.count_documents_async()
-        for collection_name, store in server_context.stores.items()
-    }
+    document_counts = {}
+    for collection_name, store in server_context.stores.items():
+        try:
+            document_counts[collection_name] = await store.count_documents_async()
+        except Exception:
+            logger.debug("Unable to load document count for %s", collection_name, exc_info=True)
+            document_counts[collection_name] = 0
     queues = {
         "index": queue_size(server_context.ingest_queue),
         "type-specific index": queue_size(get_doc_type_queue(server_context.db)),
@@ -133,12 +159,17 @@ async def collect_monitor_data(server_context, host: str, port: int, running_too
         logger.debug("Unable to load domain and host counts", exc_info=True)
         domain_count, host_count = 0, 0
         top_domains, top_hosts = [], []
+    health_monitor = getattr(server_context, "health_monitor", None)
     return MonitorData(
         bound_address=f"{host}:{port}",
         proxy_address=proxy_address,
         model=get_generator_config().describe(),
+        model_health=health_monitor.llm_healthy if health_monitor is not None else None,
         certificate_fingerprint=certificate_fingerprint(server_context.proxy_ca_cert_path),
         database=server_context.db,
+        qdrant_host_bind=getattr(server_context, "qdrant_host", None),
+        qdrant_http_port=getattr(server_context, "qdrant_port", None),
+        qdrant_health=health_monitor.qdrant_healthy if health_monitor is not None else None,
         document_counts=document_counts,
         domain_count=domain_count,
         host_count=host_count,
@@ -187,11 +218,7 @@ class MonitorApp(App[None]):
         data = await collect_monitor_data(
             self.server_context, self.host, self.port, self.server.running_tools
         )
-        fingerprint = data.certificate_fingerprint or "unavailable"
-        self.query_one("#configuration", Static).update(
-            f"[b]Configuration[/b]\nModel: {data.model}\nMCP: {data.bound_address}\nProxy: {data.proxy_address}\n"
-            f"TLS SHA-256: {fingerprint}\nQdrant: {data.database}"
-        )
+        self.query_one("#configuration", Static).update(format_configuration_panel(data))
         queues = "\n".join(f"{name}: {size}" for name, size in data.queue_sizes.items())
         self.query_one("#queues", Static).update(f"[b]Queue status[/b]\n{queues}")
         self.query_one("#database", Static).update(format_database_panel(data.document_counts))

--- a/tests/mcp_server/test_server_bootstrap_more.py
+++ b/tests/mcp_server/test_server_bootstrap_more.py
@@ -195,6 +195,7 @@ async def test_get_server_context_low_power_builds_context(monkeypatch, tmp_path
     monkeypatch.setattr(server_context, "get_server_config", lambda: Config())
     monkeypatch.setattr(server_context, "create_qdrant_document_store", create_store)
     monkeypatch.setattr(server_context, "create_qdrant_client", create_client)
+    monkeypatch.setattr(server_context, "qdrant_host_port", lambda db: ("127.0.0.1", 49201))
     monkeypatch.setattr(server_context, "build_stores", lambda db: stores)
     monkeypatch.setattr(server_context.subprocess, "check_call", lambda *args, **kwargs: None)
     monkeypatch.setattr(server_context.asyncio, "create_subprocess_exec", create_subprocess_exec)
@@ -208,6 +209,7 @@ async def test_get_server_context_low_power_builds_context(monkeypatch, tmp_path
     assert ctx.website_context_pipeline is None
     assert ctx.stores is stores
     assert ctx.qdrant_client == "client"
+    assert (ctx.qdrant_host, ctx.qdrant_port) == ("127.0.0.1", 49201)
     assert ctx.open_world is False
     assert ctx.cache_path == os.path.join(str(tmp_path), "tool_cache")
     assert doc_stores and all(store.initialized for store in doc_stores)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -120,6 +120,36 @@ def test_wait_ready_returns_on_200_and_times_out(monkeypatch):
         db._wait_ready("http://127.0.0.1:6333", timeout_s=1)
 
 
+def test_find_available_port_uses_requested_host_and_closes_socket(monkeypatch):
+    calls = []
+
+    class Socket:
+        def getsockname(self):
+            return ("127.0.0.1", 49201)
+
+        def close(self):
+            calls.append("closed")
+
+    def create_server(address):
+        calls.append(address)
+        return Socket()
+
+    monkeypatch.setattr(db.socket, "create_server", create_server)
+
+    assert db._find_available_port("127.0.0.1") == 49201
+    assert calls == [("127.0.0.1", 0), "closed"]
+
+
+def test_find_available_port_propagates_binding_errors(monkeypatch):
+    def create_server(address):
+        raise OSError("address unavailable")
+
+    monkeypatch.setattr(db.socket, "create_server", create_server)
+
+    with pytest.raises(OSError, match="address unavailable"):
+        db._find_available_port("127.0.0.1")
+
+
 def docker_inspect(container_id="abc", running=True):
     return {
         "Id": container_id,
@@ -142,6 +172,8 @@ def test_start_qdrant_docker_creates_starts_reuses_and_errors(monkeypatch, tmp_p
 
     monkeypatch.setattr(db, "_inspect_container", inspect)
     monkeypatch.setattr(db, "_run", lambda cmd, check=True: commands.append(cmd))
+    ports = iter([49201, 49201, 49202])
+    monkeypatch.setattr(db, "_find_available_port", lambda host: next(ports))
 
     created = db._start_qdrant_docker(name="qdrant-test", storage_dir=str(tmp_path / "create"), pull=True)
     started = db._start_qdrant_docker(name="qdrant-test", storage_dir=str(tmp_path / "start"))
@@ -150,6 +182,9 @@ def test_start_qdrant_docker_creates_starts_reuses_and_errors(monkeypatch, tmp_p
     assert started.grpc_port == 63340
     assert ["docker", "pull", "qdrant/qdrant:latest"] in commands
     assert any(cmd[:3] == ["docker", "run", "-d"] for cmd in commands)
+    create_command = next(cmd for cmd in commands if cmd[:3] == ["docker", "run", "-d"])
+    assert "127.0.0.1:49201:6333" in create_command
+    assert "127.0.0.1:49202:6334" in create_command
     assert ["docker", "start", "qdrant-test"] in commands
 
     monkeypatch.setattr(db, "_inspect_container", lambda name: {"State": {"Running": True}})

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,33 @@
+import pytest
+
+import shyhurricane.health as health
+
+
+def test_qdrant_probe_creates_a_new_client_after_a_connection_failure(monkeypatch):
+    attempts = iter([ConnectionError("Qdrant is unavailable"), None])
+    created = []
+
+    class Client:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+            created.append(self)
+
+        def get_collections(self):
+            if error := next(attempts):
+                raise error
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(health, "QdrantClient", Client)
+
+    with pytest.raises(ConnectionError, match="unavailable"):
+        health.qdrant_probe("127.0.0.1", 6333)
+
+    assert health.qdrant_probe("127.0.0.1", 6333) is True
+    assert [probe_client.kwargs for probe_client in created] == [
+        {"host": "127.0.0.1", "port": 6333},
+        {"host": "127.0.0.1", "port": 6333},
+    ]
+    assert all(probe_client.closed for probe_client in created)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -6,10 +6,12 @@ from shyhurricane.db import get_domain_and_host_counts
 from shyhurricane.monitor import (
     MonitorData,
     collect_monitor_data,
+    format_configuration_panel,
     format_database_panel,
     format_domain_and_host_panel,
     top_counts,
 )
+from shyhurricane.health import HealthMonitor
 
 
 class Queue:
@@ -26,6 +28,11 @@ class Store:
 
     async def count_documents_async(self):
         return self.count
+
+
+class UnavailableStore:
+    async def count_documents_async(self):
+        raise ConnectionError("Qdrant is unavailable")
 
 
 def test_top_counts_limits_results_and_sorts_ties_by_name():
@@ -48,8 +55,12 @@ def test_format_domain_and_host_panel_includes_top_counts_and_empty_states():
         bound_address="127.0.0.1:8000",
         proxy_address="not started",
         model="Ollama llama3.2:3b at localhost:11434",
+        model_health=None,
         certificate_fingerprint=None,
         database="db",
+        qdrant_host_bind="127.0.0.1",
+        qdrant_http_port=49201,
+        qdrant_health=None,
         document_counts={},
         domain_count=2,
         host_count=0,
@@ -64,6 +75,102 @@ def test_format_domain_and_host_panel_includes_top_counts_and_empty_states():
         "[b]Domains and hosts[/b]\nDomains: 2\nHosts: 0\n[b]Top domains[/b]\n"
         "example.test: 4\nother.test: 2\n[b]Top hosts[/b]\nNo hosts indexed"
     )
+
+
+def test_format_configuration_panel_orders_dependencies_and_shows_health_indicators():
+    data = MonitorData(
+        bound_address="127.0.0.1:8000",
+        proxy_address="not started",
+        model="model",
+        model_health=True,
+        certificate_fingerprint=None,
+        database="qdrant",
+        qdrant_host_bind="127.0.0.1",
+        qdrant_http_port=49201,
+        qdrant_health=False,
+        document_counts={},
+        domain_count=0,
+        host_count=0,
+        top_domains=[],
+        top_hosts=[],
+        queue_sizes={},
+        recent_urls=[],
+        running_tools=[],
+    )
+
+    panel = format_configuration_panel(data)
+    assert panel.index("Model: model 🟢") < panel.index("Qdrant: qdrant 127.0.0.1:49201 🔴")
+    assert "Qdrant: qdrant 127.0.0.1:49201 🔴" in panel
+    assert "healthy" not in panel
+    assert "unhealthy" not in panel
+    assert "Host bind:" not in panel
+    assert "HTTP port:" not in panel
+
+
+def test_format_configuration_panel_marks_missing_qdrant_endpoint_unavailable():
+    data = MonitorData(
+        bound_address="127.0.0.1:8000",
+        proxy_address="not started",
+        model="model",
+        model_health=None,
+        certificate_fingerprint=None,
+        database="qdrant",
+        qdrant_host_bind=None,
+        qdrant_http_port=None,
+        qdrant_health=None,
+        document_counts={},
+        domain_count=0,
+        host_count=0,
+        top_domains=[],
+        top_hosts=[],
+        queue_sizes={},
+        recent_urls=[],
+        running_tools=[],
+    )
+
+    panel = format_configuration_panel(data)
+
+    assert "Qdrant: qdrant unavailable:unavailable (unavailable)" in panel
+
+
+def test_health_monitor_exposes_unavailable_then_per_service_results():
+    monitor = HealthMonitor(lambda: True, lambda: False)
+    assert monitor.qdrant_healthy is None
+    assert monitor.llm_healthy is None
+
+    assert monitor.check() is False
+    assert monitor.qdrant_healthy is True
+    assert monitor.llm_healthy is False
+
+
+def test_health_monitor_marks_connection_probe_errors_unhealthy():
+    def unavailable_qdrant():
+        raise ConnectionError("Qdrant is unavailable")
+
+    monitor = HealthMonitor(unavailable_qdrant, lambda: True)
+
+    assert monitor.check() is False
+    assert monitor.qdrant_healthy is False
+    assert monitor.llm_healthy is True
+    assert monitor.ready.is_set() is False
+
+
+def test_health_monitor_recovers_after_qdrant_probe_failure():
+    results = iter([ConnectionError("Qdrant is unavailable"), True])
+
+    def qdrant_probe():
+        result = next(results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monitor = HealthMonitor(qdrant_probe, lambda: True)
+
+    assert monitor.check() is False
+    assert monitor.qdrant_healthy is False
+    assert monitor.check() is True
+    assert monitor.qdrant_healthy is True
+    assert monitor.ready.is_set() is True
 
 
 @pytest.mark.asyncio
@@ -113,6 +220,9 @@ async def test_collect_monitor_data_includes_runtime_configuration_and_statistic
         proxy_port=8010,
         proxy_ca_cert_path=certificate,
         qdrant_client=object(),
+        qdrant_host="127.0.0.1",
+        qdrant_port=49201,
+        health_monitor=SimpleNamespace(llm_healthy=True, qdrant_healthy=False),
     )
 
     async def recent_urls(*args, **kwargs):
@@ -141,8 +251,12 @@ async def test_collect_monitor_data_includes_runtime_configuration_and_statistic
         bound_address="127.0.0.1:8000",
         proxy_address="127.0.0.1:8010",
         model="OpenAI gpt-5-nano",
+        model_health=True,
         certificate_fingerprint=None,
         database="/tmp/shyhurricane.db",
+        qdrant_host_bind="127.0.0.1",
+        qdrant_http_port=49201,
+        qdrant_health=False,
         document_counts={"content": 12, "network": 8},
         domain_count=3,
         host_count=5,
@@ -168,6 +282,43 @@ async def test_collect_monitor_data_includes_runtime_configuration_and_statistic
 
 
 @pytest.mark.asyncio
+async def test_collect_monitor_data_tolerates_unavailable_qdrant_document_counts(monkeypatch):
+    context = SimpleNamespace(
+        db="qdrant:6333",
+        ingest_queue=Queue(0),
+        task_queue=Queue(0),
+        spider_result_queue=Queue(0),
+        port_scan_result_queue=Queue(0),
+        dir_busting_result_queue=Queue(0),
+        stores={"javascript": UnavailableStore()},
+        proxy_host=None,
+        proxy_port=None,
+        proxy_ca_cert_path=None,
+        qdrant_client=object(),
+        health_monitor=SimpleNamespace(llm_healthy=True, qdrant_healthy=False),
+    )
+
+    monkeypatch.setattr("shyhurricane.monitor.get_doc_type_queue", lambda db: Queue(0))
+    monkeypatch.setattr(
+        "shyhurricane.monitor.get_generator_config",
+        lambda: SimpleNamespace(describe=lambda: "model"),
+    )
+
+    async def recent_urls(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr("shyhurricane.monitor.get_recent_indexed_urls", recent_urls)
+    monkeypatch.setattr(
+        "shyhurricane.monitor.get_domain_and_host_counts", lambda *args: ({}, {}),
+    )
+
+    data = await collect_monitor_data(context, "127.0.0.1", 8000, [])
+
+    assert data.document_counts == {"javascript": 0}
+    assert data.qdrant_health is False
+
+
+@pytest.mark.asyncio
 async def test_collect_monitor_data_tolerates_unavailable_optional_data(monkeypatch):
     context = SimpleNamespace(
         db="qdrant:6333",
@@ -181,6 +332,7 @@ async def test_collect_monitor_data_tolerates_unavailable_optional_data(monkeypa
         proxy_port=None,
         proxy_ca_cert_path=None,
         qdrant_client=object(),
+        health_monitor=None,
     )
 
     monkeypatch.setattr("shyhurricane.monitor.get_doc_type_queue", lambda db: Queue(0))
@@ -204,6 +356,8 @@ async def test_collect_monitor_data_tolerates_unavailable_optional_data(monkeypa
 
     assert data.proxy_address == "not started"
     assert data.model == "Ollama llama3.2:3b at localhost:11434"
+    assert data.model_health is None
+    assert data.qdrant_health is None
     assert data.recent_urls == []
     assert data.domain_count == 0
     assert data.host_count == 0

--- a/tests/test_web_resources_worker_more.py
+++ b/tests/test_web_resources_worker_more.py
@@ -42,10 +42,34 @@ class Pipeline:
         return self.output
 
 
+class HealthState:
+    def __init__(self, healthy=False):
+        self.healthy = healthy
+        self.wait_calls = 0
+
+    def is_set(self):
+        return self.healthy
+
+    def wait(self, timeout):
+        self.wait_calls += 1
+        self.healthy = True
+
+
 def finite_queue(items):
     for item in items:
         yield item
     raise KeyboardInterrupt
+
+
+def test_wait_for_health_blocks_until_state_recovers():
+    health_state = HealthState()
+
+    assert web_resources._wait_for_health(health_state) is True
+    assert health_state.wait_calls == 1
+
+
+def test_wait_for_health_accepts_missing_state():
+    assert web_resources._wait_for_health(None) is True
 
 
 def test_ingest_worker_acks_and_queues_content_documents(monkeypatch, tmp_path):
@@ -142,7 +166,7 @@ def test_start_ingest_worker_respects_low_power(monkeypatch):
 
     assert returned_queue is queue
     assert len(processes) == 1
-    assert processes[0].target is web_resources._ingest_worker
+    assert processes[0].target is web_resources._ingest_watcher
     assert len(pool.processes) == 1
 
 
@@ -171,7 +195,7 @@ def test_start_ingest_worker_starts_doc_type_watchers_when_enabled(monkeypatch):
     assert [p.target for p in processes] == [
         web_resources._doc_type_watcher,
         web_resources._doc_type_watcher,
-        web_resources._ingest_worker,
+        web_resources._ingest_watcher,
     ]
     assert len(pool.processes) == 3
 
@@ -205,6 +229,47 @@ def test_doc_type_watcher_restarts_on_zero_exit_and_closes(monkeypatch):
     monkeypatch.setattr(web_resources.multiprocessing, "Process", Process)
 
     web_resources._doc_type_watcher("db", object())
+
+    assert len(processes) == 2
+    assert all(process.closed for process in processes)
+
+
+def test_ingest_watcher_restarts_after_health_recovers(monkeypatch):
+    processes = []
+    exitcodes = iter([0, 1])
+
+    class HealthState:
+        def __init__(self):
+            self.healthy = False
+
+        def is_set(self):
+            return self.healthy
+
+        def wait(self, timeout):
+            self.healthy = True
+
+    class Process:
+        def __init__(self, target, args):
+            self.exitcode = next(exitcodes)
+            self.closed = False
+            processes.append(self)
+
+        def start(self):
+            pass
+
+        def join(self):
+            pass
+
+        def terminate(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(web_resources, "prepare_worker_process", lambda: None)
+    monkeypatch.setattr(web_resources.multiprocessing, "Process", Process)
+
+    web_resources._ingest_watcher("db", object(), HealthState())
 
     assert len(processes) == 2
     assert all(process.closed for process in processes)


### PR DESCRIPTION
- Introduced `HealthMonitor` to track Qdrant and LLM readiness.
- Paused indexing workers gracefully when dependencies are unhealthy, resuming automatically upon recovery.
- Added health indicators in TTY monitoring for Qdrant and LLM.
- Improved Qdrant port selection during Docker initialization, avoiding binding conflicts.
- Enhanced error handling for Qdrant disconnections and health checks.